### PR TITLE
Remove background color from reaction emoji

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -40,7 +40,6 @@
 .reaction-summary-item img {
 	max-width: 100%;
 	border-radius: inherit;
-	background-color: var(--background);
 }
 
 /* Overlap reaction avatars when there are 5+ types of reactions */


### PR DESCRIPTION
Fixes #9 

Reactions by default have a transparent background, so there is no need to set the background color to a solid white color.