### PR TITLE
optimize dark mode support for reactions avatars

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -10,9 +10,6 @@
 	padding-right: 0.7em !important;
 	padding-left: 0.7em !important;
 }
-.reaction-summary-item.user-has-reacted {
-	--background: #f2f8fa;
-}
 .reaction-summary-item a {
 	display: inline-block;
 	width: 2em;
@@ -22,7 +19,7 @@
 	margin-left: -0.2em;
 	vertical-align: middle;
 	background: #efefef; /* Placeholder before the images load */
-	box-shadow: 0 0 0 2px var(--background, #fff);
+	box-shadow: 0 0 0 2px var(--color-bg-info, #fff);
 	font-size: 10px; /* Base sizer */
 	transition: margin-left 0.2s;
 }


### PR DESCRIPTION
currently there is a hard-coded off-white ( `--background: #f2f8fa` ) `box-shadow` for the reactions avatars even in dark mode. that is not optimal.

changes cherry-picked from https://github.com/sindresorhus/refined-github/commit/a81569176db9655003bd6963db41e86acdfa9720